### PR TITLE
Add enumerate() examples to supplies_list_range_ex.py

### DIFF
--- a/supplies_list_range_ex.py
+++ b/supplies_list_range_ex.py
@@ -1,14 +1,45 @@
-#-----------------------------------------------------------------------
+# -----------------------------------------------------------------------
 #
 #   supplies_list_range_ex.py - a python script showing example using
 #                               range in lists
 #
-#---------------------    module history   -----------------------------
+# ---------------------    module history   -----------------------------
 #
 #   12-OCT-18 : PTR XXXX, Created, Dodd M. Thomas
 #
-#-----------------------------------------------------------------------
- 
+#   01-DEC-18 : PTR XXXX, added enumerate() example, Logan Thomas
+#
+# -----------------------------------------------------------------------
+
 supplies = ['pens', 'grenades', 'flame-throwers', 'staples']
 for i in range(len(supplies)):
-   print('INDEX=> ' + str(i) + ' in supplies is: ' + supplies[i])
+    print('INDEX=> ' + str(i) + ' in supplies is: ' + supplies[i])
+
+# yields=>
+# INDEX=> 0 in supplies is: pens
+# INDEX=> 1 in supplies is: grenades
+# INDEX=> 2 in supplies is: flame-throwers
+# INDEX=> 3 in supplies is: staples
+
+# More pythonic approach is to use  enumerate()
+supplies = ['pens', 'grenades', 'flame-throwers', 'staples']
+for i,item in enumerate(supplies):
+    print('INDEX=> ' + str(i) + ' in supplies is: ' + item)
+
+# yields=>
+# INDEX=> 0 in supplies is: pens
+# INDEX=> 1 in supplies is: grenades
+# INDEX=> 2 in supplies is: flame-throwers
+# INDEX=> 3 in supplies is: staples
+
+# Can also specify starting index with enumerate()
+supplies = ['pens', 'grenades', 'flame-throwers', 'staples']
+for i,item in enumerate(supplies, 5):
+    print('INDEX=> ' + str(i) + ' in supplies is: ' + item)
+
+# yields=>
+# INDEX=> 5 in supplies is: pens
+# INDEX=> 6 in supplies is: grenades
+# INDEX=> 7 in supplies is: flame-throwers
+# INDEX=> 8 in supplies is: staples
+


### PR DESCRIPTION
Although using `for i in range(len(supplies))` works,
you will still need to look up the index of each item
using `i` (i.e., `supplies[i]`). This is not the most
efficient approach.

Instead, consider using `for i,item in enumerate(supplies)`.
This will return an index (`i`) and the item corresponding
to that index within supplies (i.e., `item` == `supplies[i]`).
With this approach, enumerate() takes care of the indexing
for you and is more efficient.

Resolves: #4