### PR TITLE
Add error handling examples

### DIFF
--- a/exception_ex.py
+++ b/exception_ex.py
@@ -8,14 +8,93 @@
 #   12-OCT-18 : PTR XXXX, Created, Dodd M. Thomas
 #
 #-----------------------------------------------------------------------
- 
+
+
 def spam(divide_by):
-   try:
+    try:
         return 42 / divide_by
-   except ZeroDivisionError:
+    except ZeroDivisionError:
         print('ERROR: invalid argument')
- 
+
+
 print(spam(2))
+# yields => 21.0
+
 print(spam(12))
+# yields => 3.5
+
 print(spam(0))
+# yields => ERROR: invalid argument
+#           None
+
 print(spam(1))
+# yields => 42.0
+
+
+# Example of Traceback
+42 / 0
+
+# yields =>
+
+# ---------------------------------------------------------------------------
+# ZeroDivisionError                         Traceback (most recent call last)
+# <ipython-input-11-892840ca7299> in <module>
+# ----> 1 42/0
+
+# ZeroDivisionError: division by zero
+
+
+# Can print the message of the error by capturing the error
+def spam_message_only(divide_by):
+    try:
+        return 42 / divide_by
+    except ZeroDivisionError as e:
+        print(e)
+
+
+print(spam_message_only(0))
+# yields => division by zero
+#           None
+
+
+# Can capture ANY exception and print class and message
+def spam_name_message(divide_by):
+    try:
+        return 42 / divide_by
+    except Exception as e:
+        print(e.__class__.__name__, e)
+
+
+print(spam_name_message(0))
+# yields => ZeroDivisionError division by zero
+#           None
+
+
+# Can create custom exception
+class FavoriteNumberError(Exception):
+    # Save the divide_by number used
+    def __init__(self, number):
+        self.number = number
+
+    # Define an error message
+    def __str__(self):
+        return f'{self.number} is my favorite number and cannot be used here!'
+
+
+def spam_custom(divide_by):
+    try:
+        if divide_by == 5:
+            raise FavoriteNumberError(5)
+        return 42 / divide_by
+    except (ZeroDivisionError, FavoriteNumberError) as e:
+        print(e)
+
+
+print(spam_custom(0))
+# yields => division by zero
+#           None
+
+print(spam_custom(5))
+# yields => 5 is my favorite number and cannot be used here!
+#           None
+


### PR DESCRIPTION
In python, errors should never pass silently. You can capture
errors with a try/except statement. I added a few examples of how
you can capture a specific Exception and print only its error message.
You can also capture any Exception and print its class as well as
its error message. Finally, I added an example of how you can
create your own custom Exception and have it raised within a function.